### PR TITLE
add missing name attribute to canBuyCharges checkbox

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
                 <label for="userSelect">User:</label> <select id="userSelect" required></select>
                 <label for="canBuyCharges">Can buy paint charges when running out:</label>
                 <div class="checkbox">
-                    <input class="input" id="canBuyCharges" type="checkbox" required>
+                    <input class="input" id="canBuyCharges" name="canBuyCharges" type="checkbox">
                     <label for="canBuyCharges"></label>
                 </div>
                 <button type="submit" id="submitTemplate"><img src="icons/addTemplate.svg">Add</button>


### PR DESCRIPTION
Resolves "An invalid form control with name='' is not focusable" error when submitting template form. Also removed unnecessary required attribute from checkbox as unchecked state is valid