### PR TITLE
Added border radius input for canvas preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,11 @@
             <div id="details" style="display: none;">
                 <b>Size:</b> <span id="size"></span> | <b>Charges needed:</b> <span id="ink"></span>
                 <canvas id="templateCanvas"></canvas>
-                <button id="previewCanvasButton" class="secondary-button">Preview Canvas</button>
+                <div class="preview-controls">
+                    <button id="previewCanvasButton" class="secondary-button">Preview Canvas</button>
+                    <label for="previewBorder">Preview Border:</label>
+                    <input type="text" inputmode="numeric" pattern="[0-9]*" id="previewBorder" value="0">
+                </div>
                 <canvas id="previewCanvas"></canvas>
             </div>
             <form id="templateForm">

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -185,7 +185,7 @@ const loadTemplates = async (f) => {
 };
 const fetchCanvas = async (txVal, tyVal, pxVal, pyVal, width, height) => {
     const TILE_SIZE = 1000;
-    const radius = parseInt(previewBorder.value, 10) || 0;
+    const radius = Math.max(0, parseInt(previewBorder.value, 10) || 0);
     
     const startX = txVal * TILE_SIZE + pxVal - radius;
     const startY = tyVal * TILE_SIZE + pyVal - radius;

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -21,6 +21,7 @@ const ink = $("ink");
 const templateCanvas = $("templateCanvas");
 const previewCanvas = $("previewCanvas");
 const previewCanvasButton = $("previewCanvasButton");
+const previewBorder = $("previewBorder");
 const templateForm = $("templateForm");
 const templateFormTitle = $("templateFormTitle");
 const convertInput = $("convertInput");
@@ -184,19 +185,24 @@ const loadTemplates = async (f) => {
 };
 const fetchCanvas = async (txVal, tyVal, pxVal, pyVal, width, height) => {
     const TILE_SIZE = 1000;
-    const startX = txVal * TILE_SIZE + pxVal;
-    const startY = tyVal * TILE_SIZE + pyVal;
-    const endX = startX + width;
-    const endY = startY + height;
+    const radius = parseInt(previewBorder.value, 10) || 0;
+    
+    const startX = txVal * TILE_SIZE + pxVal - radius;
+    const startY = tyVal * TILE_SIZE + pyVal - radius;
+    const displayWidth = width + (radius * 2);
+    const displayHeight = height + (radius * 2);
+    const endX = startX + displayWidth;
+    const endY = startY + displayHeight;
+    
     const startTileX = Math.floor(startX / TILE_SIZE);
     const startTileY = Math.floor(startY / TILE_SIZE);
     const endTileX = Math.floor((endX - 1) / TILE_SIZE);
     const endTileY = Math.floor((endY - 1) / TILE_SIZE);
 
-    previewCanvas.width = width;
-    previewCanvas.height = height;
+    previewCanvas.width = displayWidth;
+    previewCanvas.height = displayHeight;
     const ctx = previewCanvas.getContext('2d');
-    ctx.clearRect(0, 0, width, height);
+    ctx.clearRect(0, 0, displayWidth, displayHeight);
 
     for (let txi = startTileX; txi <= endTileX; txi++) {
         for (let tyi = startTileY; tyi <= endTileY; tyi++) {
@@ -221,24 +227,29 @@ const fetchCanvas = async (txVal, tyVal, pxVal, pyVal, width, height) => {
         }
     }
 
-    const baseImage = ctx.getImageData(0, 0, width, height);
+    const baseImage = ctx.getImageData(0, 0, displayWidth, displayHeight);
     const templateCtx = templateCanvas.getContext('2d');
     const templateImage = templateCtx.getImageData(0, 0, width, height);
     ctx.globalAlpha = 0.5;
-    ctx.drawImage(templateCanvas, 0, 0);
+    ctx.drawImage(templateCanvas, radius, radius);
     ctx.globalAlpha = 1;
     const b = baseImage.data;
     const t = templateImage.data;
     for (let i = 0; i < t.length; i += 4) {
         // skip transparent template pixels
         if (t[i + 3] === 0) continue;
-        if (b[i + 3] === 0) continue;
 
-        const idx = i / 4;
-        const x = idx % width;
-        const y = Math.floor(idx / width);
+        const templateIdx = i / 4;
+        const templateX = templateIdx % width;
+        const templateY = Math.floor(templateIdx / width);
+        const canvasX = templateX + radius;
+        const canvasY = templateY + radius;
+        const canvasIdx = (canvasY * displayWidth + canvasX) * 4;
+        
+        if (b[canvasIdx + 3] === 0) continue;
+
         ctx.fillStyle = 'rgba(255,0,0,0.8)';
-        ctx.fillRect(x, y, 1, 1);
+        ctx.fillRect(canvasX, canvasY, 1, 1);
     }
 };
 

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -325,6 +325,31 @@ canvas {
     margin: 16px 0;
 }
 
+.preview-controls {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin: 16px 0;
+}
+
+.preview-controls button {
+    flex: 1;
+    margin-bottom: 0;
+}
+
+.preview-controls label {
+    margin: 0;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.preview-controls input {
+    width: 100px;
+    margin: 0;
+    flex-shrink: 0;
+}
+
 #templateList {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Added "Preview Border" input field to template preview controls.

Allows users to specify extra pixels around template preview for better context visualization

<img width="1574" height="1604" alt="image" src="https://github.com/user-attachments/assets/5024db30-8a00-49de-a4a9-711ce7fc5210" />
