### PR TITLE
Fix: Remove async from log function to prevent EBUSY race condition crash

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ if (!existsSync(dataDir)) {
 }
 
 // --- Logging and Utility Functions ---
-const log = async (id, name, data, error) => {
+const log =  (id, name, data, error) => {
     const timestamp = new Date().toLocaleString();
     const identifier = `(${name}#${id})`;
     if (error) {


### PR DESCRIPTION
Fixes #144 

This pull request fixes a critical crash caused by an "EBUSY: resource busy or locked" error when writing to the log file.

The "log" function in "server.js" was declared as "async" but used the synchronous "appendFileSync", Because it wasn't awaited, multiple calls to "log" could happen simultaneously, creating a race condition where two operations tried to get a lock on the same log file at the same time, causing the script to crash.

The error still persists, but it doesn't end the entire application anymore and painting continues as normal!
