### PR TITLE
Fix logging race condition v2

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ if (!existsSync(dataDir)) {
 }
 
 // --- Logging and Utility Functions ---
-const log = async (id, name, data, error) => {
+const log =  (id, name, data, error) => {
     const timestamp = new Date().toLocaleString();
     const identifier = `(${name}#${id})`;
     if (error) {

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { appendFile } from 'fs/promises';
 import path from "node:path";
 import express from "express";
 import cors from "cors";
@@ -13,16 +14,19 @@ if (!existsSync(dataDir)) {
 }
 
 // --- Logging and Utility Functions ---
-const log =  (id, name, data, error) => {
+const log = async (id, name, data, error) => {
     const timestamp = new Date().toLocaleString();
     const identifier = `(${name}#${id})`;
+    
     if (error) {
         console.error(`[${timestamp}] ${identifier} ${data}:`, error);
-        appendFileSync(path.join(dataDir, `errors.log`), `[${timestamp}] ${identifier} ${data}: ${error.stack || error.message}\n`);
+        await appendFile(path.join(dataDir, `errors.log`), 
+            `[${timestamp}] ${identifier} ${data}: ${error.stack || error.message}\n`);
     } else {
         console.log(`[${timestamp}] ${identifier} ${data}`);
-        appendFileSync(path.join(dataDir, `logs.log`), `[${timestamp}] ${identifier} ${data}\n`);
-    };
+        await appendFile(path.join(dataDir, `logs.log`), 
+            `[${timestamp}] ${identifier} ${data}\n`);
+    }
 };
 
 const duration = (durationMs) => {


### PR DESCRIPTION
The logging function was causing crashes on Windows when multiple logs happened at the same time. I rewrote it to use proper async operations, so now logs and errors are saved safely without blocking anything.

Fixed this yesterday by just making the log function not async (#145), looks like the bug is back in main, this is a better implementation and in my testing also provides better logging (less errors and the "⏱️ Waiting for account turn cooldown (29s)." actually shows up for me! :)